### PR TITLE
40 string.Compare ==> IsBefore, IsAfter, IsBeforeOrEqual, etc.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,4 @@
 
 ## By version
 
-* [v0.1](v0.1/index.md)
+* [v0.x](v0.x/index.md)

--- a/docs/v0.x/String_IsAfter.md
+++ b/docs/v0.x/String_IsAfter.md
@@ -1,9 +1,9 @@
-# string.IsBeforeOrEqualTo(...)
+# string.IsAfter(...)
 
-An extension method to determine if a string comes before or is equal to another.
+An extension method to determine if a string comes after another.
 
 ---
-## `bool IsBeforeOrEqualTo(this string lhs, string rhs, StringComparison comparisonType)`
+## `bool IsAfter(this string lhs, string rhs, StringComparison comparisonType)`
 
 ### Parameters
 
@@ -16,5 +16,5 @@ An extension method to determine if a string comes before or is equal to another
 ```csharp
 string a = "A";
 string b = "B";
-bool result = a.IsBeforeOrEqualTo(b, StringComparison.OrdinalIgnoreCase); // true
+bool result = b.IsAfter(a, StringComparison.OrdinalIgnoreCase); // true
 ```

--- a/docs/v0.x/String_IsAfterOrEqualTo.md
+++ b/docs/v0.x/String_IsAfterOrEqualTo.md
@@ -1,0 +1,20 @@
+# string.IsAfterOrEqualTo(...)
+
+An extension method to determine if a string comes after or is equal to another.
+
+---
+## `bool IsAfterOrEqualTo(this string lhs, string rhs, StringComparison comparisonType)`
+
+### Parameters
+
+* `lhs`: The left hand side of the operation.
+* `rhs`: The right hand side of the operation.
+* `comparisonType`: An enum defining the type of comparison. (See [StringComparison](https://learn.microsoft.com/en-us/dotnet/api/System.StringComparison?view=netstandard-2.0))
+
+### Example
+
+```csharp
+string a = "A";
+string b = "B";
+bool result = b.IsAfterOrEqualTo(a, StringComparison.OrdinalIgnoreCase); // true
+```

--- a/docs/v0.x/String_IsBefore.md
+++ b/docs/v0.x/String_IsBefore.md
@@ -1,0 +1,21 @@
+# string.IsBefore(...)
+
+An extension method to determine if a string comes before another.
+
+---
+## `bool IsBefore(this string lhs, string rhs, StringComparison comparisonType)`
+
+### Parameters
+
+* `lhs`: The left hand side of the operation.
+* `rhs`: The right hand side of the operation.
+* `comparisonType`: An enum defining the type of comparison. (See [StringComparison](https://learn.microsoft.com/en-us/dotnet/api/System.StringComparison?view=netstandard-2.0))
+
+### Example
+
+```csharp
+string a = "A";
+string b = "B";
+bool result = a.IsBefore(b, StringComparison.OrdinalIgnoreCase); // true
+});
+```

--- a/docs/v0.x/String_IsBefore.md
+++ b/docs/v0.x/String_IsBefore.md
@@ -17,5 +17,4 @@ An extension method to determine if a string comes before another.
 string a = "A";
 string b = "B";
 bool result = a.IsBefore(b, StringComparison.OrdinalIgnoreCase); // true
-});
 ```

--- a/docs/v0.x/String_IsBeforeOrEqualTo.md
+++ b/docs/v0.x/String_IsBeforeOrEqualTo.md
@@ -1,0 +1,21 @@
+# string.IsBeforeOrEqualTo(...)
+
+An extension method to determine if a string comes before or is equal to another.
+
+---
+## `bool IsBeforeOrEqualTo(this string lhs, string rhs, StringComparison comparisonType)`
+
+### Parameters
+
+* `lhs`: The left hand side of the operation.
+* `rhs`: The right hand side of the operation.
+* `comparisonType`: An enum defining the type of comparison. (See [StringComparison](https://learn.microsoft.com/en-us/dotnet/api/System.StringComparison?view=netstandard-2.0))
+
+### Example
+
+```csharp
+string a = "A";
+string b = "B";
+bool result = a.IsBeforeOrEqualTo(b, StringComparison.OrdinalIgnoreCase); // true
+});
+```

--- a/docs/v0.x/index.md
+++ b/docs/v0.x/index.md
@@ -14,5 +14,6 @@
 ## String Extensions
 
 * [HasContent](String_HasContent.md)
+* [IsAfter](String_IsAfter.md)
 * [IsBefore](String_IsBefore.md)
 * [IsBeforeOrEqualTo](String_IsBeforeOrEqualTo.md)

--- a/docs/v0.x/index.md
+++ b/docs/v0.x/index.md
@@ -14,3 +14,4 @@
 ## String Extensions
 
 * [HasContent](String_HasContent.md)
+* [IsBefore](String_IsBefore.md)

--- a/docs/v0.x/index.md
+++ b/docs/v0.x/index.md
@@ -15,3 +15,4 @@
 
 * [HasContent](String_HasContent.md)
 * [IsBefore](String_IsBefore.md)
+* [IsBeforeOrEqualTo](String_IsBeforeOrEqualTo.md)

--- a/docs/v0.x/index.md
+++ b/docs/v0.x/index.md
@@ -15,5 +15,6 @@
 
 * [HasContent](String_HasContent.md)
 * [IsAfter](String_IsAfter.md)
+* [IsAfterOrEqualTo](String_IsAfterOrEqualTo.md)
 * [IsBefore](String_IsBefore.md)
 * [IsBeforeOrEqualTo](String_IsBeforeOrEqualTo.md)

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -10,6 +10,6 @@ Date: ???
 - Added `ForEach` and `ForEachAsync` extension methods.
 - #2: Added `IsEmpty` and `IsNullOrEmpty` extension methods.
 - #31: Added `ToDictionary` extension methods.
-
+- #40: Added `IsAfter`, `IsAfterOrEqualTo`, `IsBefore` and `IsBeforeOrEqualTo` string extensions.
 
 

--- a/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
+++ b/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Stravaig.Extensions.Core.Tests;
+
+[TestFixture]
+// ReSharper disable once InconsistentNaming
+public class StringExtensions_CompareExtensionsTests
+{
+    [Test]
+    public void AIsBeforeBReturnsTrue()
+    {
+        "A".IsBefore("B", StringComparison.Ordinal).ShouldBeTrue();
+        "a".IsBefore("B", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "A".IsBefore("b", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "a".IsBefore("b", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+    }
+    
+    [Test]
+    public void AIsBeforeAReturnsFalse()
+    {
+        "A".IsBefore("A", StringComparison.Ordinal).ShouldBeFalse();
+        "a".IsBefore("A", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "A".IsBefore("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "a".IsBefore("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+    }
+    
+    [Test]
+    public void BIsBeforeAReturnsFalse()
+    {
+        "B".IsBefore("A", StringComparison.Ordinal).ShouldBeFalse();
+        "b".IsBefore("A", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "B".IsBefore("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "b".IsBefore("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+    }
+
+}

--- a/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
+++ b/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
@@ -33,6 +33,32 @@ public class StringExtensions_CompareExtensionsTests
         "b".IsAfter("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
     }
     
+    [Test]
+    public void AIsAfterOrEqualToBReturnsFalse()
+    {
+        "A".IsAfterOrEqualTo("B", StringComparison.Ordinal).ShouldBeFalse();
+        "a".IsAfterOrEqualTo("B", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "A".IsAfterOrEqualTo("b", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "a".IsAfterOrEqualTo("b", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+    }
+    
+    [Test]
+    public void AIsAfterOrEqualToAReturnsTrue()
+    {
+        "A".IsAfterOrEqualTo("A", StringComparison.Ordinal).ShouldBeTrue();
+        "a".IsAfterOrEqualTo("A", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "A".IsAfterOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "a".IsAfterOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+    }
+    
+    [Test]
+    public void BIsAfterOrEqualToAReturnsTrue()
+    {
+        "B".IsAfterOrEqualTo("A", StringComparison.Ordinal).ShouldBeTrue();
+        "b".IsAfterOrEqualTo("A", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "B".IsAfterOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "b".IsAfterOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+    }
     
     [Test]
     public void AIsBeforeBReturnsTrue()

--- a/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
+++ b/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
@@ -33,4 +33,30 @@ public class StringExtensions_CompareExtensionsTests
         "b".IsBefore("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
     }
 
+    [Test]
+    public void AIsBeforeOrEqualToBReturnsTrue()
+    {
+        "A".IsBeforeOrEqualTo("B", StringComparison.Ordinal).ShouldBeTrue();
+        "a".IsBeforeOrEqualTo("B", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "A".IsBeforeOrEqualTo("b", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "a".IsBeforeOrEqualTo("b", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+    }
+    
+    [Test]
+    public void AIsBeforeOrEqualToAReturnsTrue()
+    {
+        "A".IsBeforeOrEqualTo("A", StringComparison.Ordinal).ShouldBeTrue();
+        "a".IsBeforeOrEqualTo("A", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "A".IsBeforeOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "a".IsBeforeOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+    }
+    
+    [Test]
+    public void BIsBeforeOrEqualToAReturnsFalse()
+    {
+        "B".IsBeforeOrEqualTo("A", StringComparison.Ordinal).ShouldBeFalse();
+        "b".IsBeforeOrEqualTo("A", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "B".IsBeforeOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "b".IsBeforeOrEqualTo("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+    }
 }

--- a/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
+++ b/src/Stravaig.Extensions.Core.Tests/StringExtensions_CompareExtensionsTests.cs
@@ -7,6 +7,34 @@ namespace Stravaig.Extensions.Core.Tests;
 public class StringExtensions_CompareExtensionsTests
 {
     [Test]
+    public void AIsAfterBReturnsFalse()
+    {
+        "A".IsAfter("B", StringComparison.Ordinal).ShouldBeFalse();
+        "a".IsAfter("B", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "A".IsAfter("b", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "a".IsAfter("b", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+    }
+    
+    [Test]
+    public void AIsAfterAReturnsFalse()
+    {
+        "A".IsAfter("A", StringComparison.Ordinal).ShouldBeFalse();
+        "a".IsAfter("A", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "A".IsAfter("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+        "a".IsAfter("a", StringComparison.OrdinalIgnoreCase).ShouldBeFalse();
+    }
+    
+    [Test]
+    public void BIsAfterAReturnsTrue()
+    {
+        "B".IsAfter("A", StringComparison.Ordinal).ShouldBeTrue();
+        "b".IsAfter("A", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "B".IsAfter("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+        "b".IsAfter("a", StringComparison.OrdinalIgnoreCase).ShouldBeTrue();
+    }
+    
+    
+    [Test]
     public void AIsBeforeBReturnsTrue()
     {
         "A".IsBefore("B", StringComparison.Ordinal).ShouldBeTrue();

--- a/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
+++ b/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
@@ -10,6 +10,21 @@ namespace Stravaig.Extensions.Core;
 public static class StringExtensions_CompareExtensions
 {
     /// <summary>
+    /// Determines whether lhs comes after rhs given the type of comparison used.
+    /// </summary>
+    /// <param name="lhs">The string on the left hand side of the comparison.</param>
+    /// <param name="rhs">The string on the right hand side of the comparison.</param>
+    /// <param name="comparisonType">One of the enumeration values that
+    /// specifies the rules to use in the comparison.</param>
+    /// <returns>True if the left string comes after the right string.</returns>
+    [Pure]
+    public static bool IsAfter(this string lhs, string rhs, StringComparison comparisonType)
+    {
+        return string.Compare(lhs, rhs, comparisonType) > 0;
+    }
+
+    
+    /// <summary>
     /// Determines whether lhs comes before rhs given the type of comparison used.
     /// </summary>
     /// <param name="lhs">The string on the left hand side of the comparison.</param>
@@ -31,10 +46,13 @@ public static class StringExtensions_CompareExtensions
     /// <param name="rhs">The string on the right hand side of the comparison.</param>
     /// <param name="comparisonType">One of the enumeration values that
     /// specifies the rules to use in the comparison.</param>
-    /// <returns>True if the left string comes before the right string.</returns>
+    /// <returns>True if the left string comes before or is equal to the right
+    /// string.</returns>
     [Pure]
     public static bool IsBeforeOrEqualTo(this string lhs, string rhs, StringComparison comparisonType)
     {
         return string.Compare(lhs, rhs, comparisonType) <= 0;
     }
+    
+    
 }

--- a/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
+++ b/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
@@ -23,6 +23,20 @@ public static class StringExtensions_CompareExtensions
         return string.Compare(lhs, rhs, comparisonType) > 0;
     }
 
+    /// <summary>
+    /// Determines whether lhs comes after or is equal to the rhs given the type
+    /// of comparison used.
+    /// </summary>
+    /// <param name="lhs">The string on the left hand side of the comparison.</param>
+    /// <param name="rhs">The string on the right hand side of the comparison.</param>
+    /// <param name="comparisonType">One of the enumeration values that
+    /// specifies the rules to use in the comparison.</param>
+    /// <returns>True if the left string comes after the right string.</returns>
+    [Pure]
+    public static bool IsAfterOrEqualTo(this string lhs, string rhs, StringComparison comparisonType)
+    {
+        return string.Compare(lhs, rhs, comparisonType) >= 0;
+    }
     
     /// <summary>
     /// Determines whether lhs comes before rhs given the type of comparison used.

--- a/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
+++ b/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Diagnostics.Contracts;
+
+namespace Stravaig.Extensions.Core;
+
+/// <summary>
+/// String extensions that extend the comparison functionality.
+/// </summary>
+// ReSharper disable once InconsistentNaming
+public static class StringExtensions_CompareExtensions
+{
+    /// <summary>
+    /// Determines whether lhs comes before rhs given the type of comparison used.
+    /// </summary>
+    /// <param name="lhs">The string on the left hand side of the comparison.</param>
+    /// <param name="rhs">The string on the right hand side of the comparison.</param>
+    /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
+    /// <returns>True if the left string comes before the right string.</returns>
+    [Pure]
+    public static bool IsBefore(this string lhs, string rhs, StringComparison comparisonType)
+    {
+        return string.Compare(lhs, rhs, comparisonType) < 0;
+    }
+}

--- a/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
+++ b/src/Stravaig.Extensions.Core/StringExtensions_CompareExtensions.cs
@@ -14,11 +14,27 @@ public static class StringExtensions_CompareExtensions
     /// </summary>
     /// <param name="lhs">The string on the left hand side of the comparison.</param>
     /// <param name="rhs">The string on the right hand side of the comparison.</param>
-    /// <param name="comparisonType">One of the enumeration values that specifies the rules to use in the comparison.</param>
+    /// <param name="comparisonType">One of the enumeration values that
+    /// specifies the rules to use in the comparison.</param>
     /// <returns>True if the left string comes before the right string.</returns>
     [Pure]
     public static bool IsBefore(this string lhs, string rhs, StringComparison comparisonType)
     {
         return string.Compare(lhs, rhs, comparisonType) < 0;
+    }
+
+    /// <summary>
+    /// Determines whether lhs comes before or is equal to the rhs given the
+    /// type of comparison used.
+    /// </summary>
+    /// <param name="lhs">The string on the left hand side of the comparison.</param>
+    /// <param name="rhs">The string on the right hand side of the comparison.</param>
+    /// <param name="comparisonType">One of the enumeration values that
+    /// specifies the rules to use in the comparison.</param>
+    /// <returns>True if the left string comes before the right string.</returns>
+    [Pure]
+    public static bool IsBeforeOrEqualTo(this string lhs, string rhs, StringComparison comparisonType)
+    {
+        return string.Compare(lhs, rhs, comparisonType) <= 0;
     }
 }


### PR DESCRIPTION
# string.Is(Before(OrEqualTo))(After(OrEqualTo))

## Issue

This PR addresses Issue #40.

<!-- Fill in any additional notes about the PR here -->

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the `readme.md` file & Documentation.
- [x] I have bumped the version number in the `version.txt`.
- [x] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.
