### PR TITLE
#44: Automatically update metadata in documentation on a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,14 +166,20 @@ jobs:
         shell: pwsh
         run: ./Reset-WipReleaseNotes.ps1
         
+      - name: Update Docs
+        #IF Publishing & Stable release
+        if: ${{ env.STRAVAIG_PUBLISH_TO_NUGET == 'true' && env.STRAVAIG_IS_STABLE == 'true' }}
+        shell: pwsh
+        run: ./Update-Docs.ps1
+
       - name: Commit post release updates
         #IF Publishing & Stable release
         if: ${{ env.STRAVAIG_PUBLISH_TO_NUGET == 'true' && env.STRAVAIG_IS_STABLE == 'true' }}
         uses: EndBug/add-and-commit@v5
         with:
-          add: ./contributors.md ./release-notes/** ./version.txt
+          add: ./contributors.md ./release-notes/** ./version.txt ./docs/**
           author_name: StravaigBot
           author_email: github-bot@stravaig.scot
-          message: "[bot] Post v${{ env.STRAVAIG_PACKAGE_FULL_VERSION }} Release & Bump Version updates."
+          message: "[bot] Update metadata post v${{ env.STRAVAIG_PACKAGE_FULL_VERSION }} release."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,4 +10,9 @@ Some core extensions that make developing easier.
 
 # Documentation
 
-For the current version, see: https://stravaig-projects.github.io/Stravaig.Extensions.Core/v0.x/
+* [Main Documentation](https://stravaig-projects.github.io/Stravaig.Extensions.Core/)
+* [Current Version](https://stravaig-projects.github.io/Stravaig.Extensions.Core/v0.x/)
+* [Contributors](https://stravaig-projects.github.io/Stravaig.Extensions.Core/contributors.html)
+* [Release Notes](https://stravaig-projects.github.io/Stravaig.Extensions.Core/release-notes/)
+
+

--- a/Update-Docs.ps1
+++ b/Update-Docs.ps1
@@ -1,0 +1,24 @@
+Copy-Item "$PSScriptRoot/contributors.md" "$PSScriptRoot/docs/contributors.md"
+
+Copy-Item "$PSScriptRoot/release-notes/release-notes-*.md" "$PSScriptRoot/docs/release-notes/"
+
+$releaseNotesIndexFile = @(
+"# Release Notes"
+""
+"The releases on this package most recent first."
+""
+);
+
+Get-ChildItem "$PSScriptRoot/docs/release-notes/release-notes*.md" |
+    Sort-Object -Descending -Property Name |
+    ForEach-Object -Process {
+        $name = $_.Name;
+        $releaseDate = $_.LastWriteTimeUtc.ToString("dddd, d MMMM yyyy 'at' HH:mm");
+        $null = $name -match "release-notes-(?<version>[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\.md";
+        $version = $Matches.version;
+        $releaseNotesIndexFile += "* [v$version]($name) released on $releaseDate UTC";
+    }
+
+Set-Content "$PSScriptRoot/docs/release-notes/index.md" $releaseNotesIndexFile -Encoding UTF8 -Force
+
+$releaseNotesIndexFile

--- a/contributors.md
+++ b/contributors.md
@@ -2,15 +2,17 @@
 
 This is a list of all the contributors to this repository in ascending order by the contributor name.
 
-**Colin Mackay** contributed 50 commits from Saturday, 19 June, 2021 @ 22:42:41 +00:00 to Thursday, 13 April, 2023 @ 20:47:49 +00:00.
+**Colin Mackay** contributed 55 commits from Saturday, 19 June, 2021 @ 23:42:41 +01:00 to Thursday, 13 April, 2023 @ 23:33:10 +01:00.
 
-**dependabot[bot]** contributed 13 commits from Monday, 21 June, 2021 @ 13:15:16 +00:00 to Sunday, 26 March, 2023 @ 13:37:06 +00:00.
+**dependabot[bot]** contributed 13 commits from Monday, 21 June, 2021 @ 14:15:16 +01:00 to Sunday, 26 March, 2023 @ 14:37:06 +01:00.
+
+**StravaigBot** contributed 1 commit on Thursday, 13 April, 2023 @ 21:49:58 +01:00.
 
 ## Summary
 
-:octocat: 63 commits in total.
+:octocat: 69 commits in total.
 
-:date: From Saturday, 19 June, 2021 @ 22:42:41 +00:00.
+:date: From Saturday, 19 June, 2021 @ 23:42:41 +01:00.
 
-:date: Until Thursday, 13 April, 2023 @ 20:47:49 +00:00.
+:date: Until Thursday, 13 April, 2023 @ 23:33:10 +01:00.
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -2,15 +2,17 @@
 
 This is a list of all the contributors to this repository in ascending order by the contributor name.
 
-**Colin Mackay** contributed 50 commits from Saturday, 19 June, 2021 @ 22:42:41 +00:00 to Thursday, 13 April, 2023 @ 20:47:49 +00:00.
+**Colin Mackay** contributed 55 commits from Saturday, 19 June, 2021 @ 23:42:41 +01:00 to Thursday, 13 April, 2023 @ 23:33:10 +01:00.
 
-**dependabot[bot]** contributed 13 commits from Monday, 21 June, 2021 @ 13:15:16 +00:00 to Sunday, 26 March, 2023 @ 13:37:06 +00:00.
+**dependabot[bot]** contributed 13 commits from Monday, 21 June, 2021 @ 14:15:16 +01:00 to Sunday, 26 March, 2023 @ 14:37:06 +01:00.
+
+**StravaigBot** contributed 1 commit on Thursday, 13 April, 2023 @ 21:49:58 +01:00.
 
 ## Summary
 
-:octocat: 63 commits in total.
+:octocat: 69 commits in total.
 
-:date: From Saturday, 19 June, 2021 @ 22:42:41 +00:00.
+:date: From Saturday, 19 June, 2021 @ 23:42:41 +01:00.
 
-:date: Until Thursday, 13 April, 2023 @ 20:47:49 +00:00.
+:date: Until Thursday, 13 April, 2023 @ 23:33:10 +01:00.
 

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,0 +1,16 @@
+# Contributors
+
+This is a list of all the contributors to this repository in ascending order by the contributor name.
+
+**Colin Mackay** contributed 50 commits from Saturday, 19 June, 2021 @ 22:42:41 +00:00 to Thursday, 13 April, 2023 @ 20:47:49 +00:00.
+
+**dependabot[bot]** contributed 13 commits from Monday, 21 June, 2021 @ 13:15:16 +00:00 to Sunday, 26 March, 2023 @ 13:37:06 +00:00.
+
+## Summary
+
+:octocat: 63 commits in total.
+
+:date: From Saturday, 19 June, 2021 @ 22:42:41 +00:00.
+
+:date: Until Thursday, 13 April, 2023 @ 20:47:49 +00:00.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,8 @@
 ## By version
 
 * [v0.x](v0.x/index.md)
+
+## Project details
+
+* [Contributors](contributors.md)
+* [Release Notes](release-notes/index.md)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+The releases on this package most recent first.
+
+* [v0.1.0](release-notes-0.1.0.md) released on Thursday, 13 April 2023 at 20:50 UTC

--- a/docs/release-notes/release-notes-0.1.0.md
+++ b/docs/release-notes/release-notes-0.1.0.md
@@ -1,0 +1,15 @@
+# Release Notes
+
+## Version 0.1.0
+
+Date: Thursday, 13 April, 2023 at 20:49:50 +00:00
+
+### Features
+
+- Added `HasContent` string extension methods.
+- Added `ForEach` and `ForEachAsync` extension methods.
+- #2: Added `IsEmpty` and `IsNullOrEmpty` extension methods.
+- #31: Added `ToDictionary` extension methods.
+- #40: Added `IsAfter`, `IsAfterOrEqualTo`, `IsBefore` and `IsBeforeOrEqualTo` string extensions.
+
+

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -10,15 +10,6 @@ Date: ???
 
 ### Miscellaneous
 
-### Dependent Packages
-
-- .NET 5.0
-  - No changes
-- .NET Core 3.1
-  - No changes
-- General
-  - No changes
-
----
+- #45: Automatically update the metadata in the documentation on a release.
 
 


### PR DESCRIPTION
# Automatically update the metadata in the documentation on a release

## Issue

This PR addresses Issue #44.

This will update the metadata in the documentation on a release. It will add the release notes to the documentation, along with a list of the contributors.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the `readme.md` file & Documentation.
- [x] I have bumped the version number in the `version.txt`.
- [x] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.
