### PR TITLE
(#43) Upgrade out-of-date actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Archive Simulated Release Notes
         if: ${{ env.STRAVAIG_PUBLISH_TO_NUGET == 'false' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: simulated-release-information
           path: |
@@ -120,7 +120,7 @@ jobs:
 
       - name: Archive Release Notes
         if: ${{ env.STRAVAIG_PUBLISH_TO_NUGET == 'true' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-information
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,25 +66,14 @@ jobs:
           echo "Is Preview: $STRAVAIG_IS_PREVIEW"
           echo "Is Stable: $STRAVAIG_IS_STABLE"
           
-      - uses: actions/setup-dotnet@v1
-        name: Setup .NET Core 3.1 (LTS)
+      - uses: actions/setup-dotnet@v3
+        name: Setup .NET 3.1 to 7.0
         with:
-          dotnet-version: 3.1.x
-
-      - uses: actions/setup-dotnet@v1
-        name: Setup .NET 5.0 (STS)
-        with:
-          dotnet-version: 5.0.x
-          
-      - uses: actions/setup-dotnet@v1
-        name: Setup .NET 6.0 (LTS)
-        with:
-          dotnet-version: 6.0.x
-
-      - uses: actions/setup-dotnet@v1
-        name: Setup .NET 7.0 (STS)
-        with:
-          dotnet-version: 7.0.x
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
 
       - name: Build Solution
         run: dotnet build $STRAVAIG_SOLUTION --configuration Release

--- a/release-notes/wip-release-notes.md
+++ b/release-notes/wip-release-notes.md
@@ -10,6 +10,7 @@ Date: ???
 
 ### Miscellaneous
 
+- #43: Update the build actions that used a deprecated version of Node.js
 - #45: Automatically update the metadata in the documentation on a release.
 
 


### PR DESCRIPTION
# Upgrade Out-of-date actions

## Issue

This PR addresses Issue #43.

Github Actions was complaining the a number of actions were out-of-date.

## Check list

### Required

- [x] I have updated `release-notes/wip-release-notes.md` file
- [x] I have addressed style warnings given by Visual Studio/ReSharper/Rider
- [x] I have checked that all tests pass.

### Optional

<!-- 
Depending on what the PR is for these may not be needed.
If any of these items are not needed, then they can be removed.
-->

- [x] I have updated the `readme.md` file & Documentation.
- [x] I have bumped the version number in the `version.txt`.
- [x] I have added or updated any necessary tests.
- [x] I have ensured that any new code is covered by tests where reasonably possible.
